### PR TITLE
Convert carbon_plaintext.go to use our logger and stats.

### DIFF
--- a/cassabon.go
+++ b/cassabon.go
@@ -29,6 +29,11 @@ func fetchConfiguration(confFile string) {
 	}
 
 	// Copy in values sourced solely from the configuration file.
+	config.G.API.Address = cnf.API.Address
+	config.G.API.Port = cnf.API.Port
+	config.G.Carbon.Address = cnf.Carbon.Address
+	config.G.Carbon.Port = cnf.Carbon.Port
+	config.G.Carbon.Protocol = cnf.Carbon.Protocol
 }
 
 func main() {
@@ -39,7 +44,7 @@ func main() {
 	// Get options provided on the command line.
 	flag.StringVar(&confFile, "conf", "", "Location of YAML configuration file.")
 	flag.StringVar(&config.G.Log.Logdir, "logdir", "", "Name of directory to contain log files (stderr if unspecified)")
-	flag.StringVar(&config.G.Log.Loglevel, "loglevel", "debug", "Log level: debug|info|warn|error|fatal")
+	flag.StringVar(&config.G.Log.Loglevel, "loglevel", "", "Log level: debug|info|warn|error|fatal")
 	flag.StringVar(&config.G.Statsd.Host, "statsdhost", "", "statsd host or IP address")
 	flag.StringVar(&config.G.Statsd.Port, "statsdport", "8125", "statsd port")
 	flag.Parse()

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -16,7 +16,7 @@ type CassabonConfig struct {
 		Hosts []string // List of hostnames or IP addresses of Cassandra ring
 		Port  int      // Cassandra port
 	}
-	Api struct {
+	API struct {
 		Address string // HTTP API listens on this address
 		Port    string // HTTP API listens on this port
 	}

--- a/listener/carbon_plaintext_test.go
+++ b/listener/carbon_plaintext_test.go
@@ -5,9 +5,15 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/jeffpierce/cassabon/config"
+	"github.com/jeffpierce/cassabon/logging"
 )
 
 func TestCarbonSocket(t *testing.T) {
+
+	config.G.Log.System = logging.NewLogger("system", "", logging.Fatal)
+
 	fmt.Println("Testing TCP socket connection...")
 	go CarbonTCP("127.0.0.1", "2003")
 

--- a/listener/carbon_plaintext_test.go
+++ b/listener/carbon_plaintext_test.go
@@ -13,6 +13,8 @@ import (
 func TestCarbonSocket(t *testing.T) {
 
 	config.G.Log.System = logging.NewLogger("system", "", logging.Fatal)
+	config.G.Log.Carbon = logging.NewLogger("carbon", "", logging.Fatal)
+	logging.Statsd.Open("", "", "cassabon")
 
 	fmt.Println("Testing TCP socket connection...")
 	go CarbonTCP("127.0.0.1", "2003")
@@ -47,12 +49,18 @@ func TestCarbonSocket(t *testing.T) {
 }
 
 func GoodMetric(conn net.Conn) {
+	config.G.Log.System = logging.NewLogger("system", "", logging.Fatal)
+	config.G.Log.Carbon = logging.NewLogger("carbon", "", logging.Fatal)
+	logging.Statsd.Open("", "", "cassabon")
 	testMetric := fmt.Sprintf("carbon.test 1 %d", time.Now().Unix())
 	fmt.Println("Sending metric:", testMetric)
 	fmt.Fprintf(conn, testMetric+"\n")
 }
 
 func BadMetric(conn net.Conn) {
+	config.G.Log.System = logging.NewLogger("system", "", logging.Fatal)
+	config.G.Log.Carbon = logging.NewLogger("carbon", "", logging.Fatal)
+	logging.Statsd.Open("", "", "cassabon")
 	testMetric := "carbon.terrible 9 Qsplork"
 	fmt.Println("Sending bad metric:", testMetric)
 	fmt.Fprintf(conn, testMetric+"\n")

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -66,6 +66,8 @@ func TextToSeverity(s string) (Severity, error) {
 	var sev Severity = Debug
 	var err error
 	switch strings.ToLower(s) {
+	case "":
+		sev = Debug
 	case "debug":
 		sev = Debug
 	case "info":


### PR DESCRIPTION
Also implemented or fixed:

- logging level from YAML can be successfully applied
- API and Carbon address are hooked up to global state
- listener tests don't crash, after  giving them a valid logger and statsd