### PR TITLE
Stub in the queue manager.

### DIFF
--- a/config/globals.go
+++ b/config/globals.go
@@ -6,6 +6,13 @@ import (
 	"github.com/jeffpierce/cassabon/logging"
 )
 
+// CarbonMetric is the canonical representation of Carbon data.
+type CarbonMetric struct {
+	Path      string  // Metric path
+	Value     float64 // Metric Value
+	Timestamp float64 // Epoch timestamp
+}
+
 // The globally accessible configuration and state object.
 var G Globals
 
@@ -15,6 +22,9 @@ type Globals struct {
 	// Goroutine management.
 	Quit chan struct{}
 	WG   sync.WaitGroup
+
+	// Channel for sending metrics to the queue manager.
+	QueueManager chan CarbonMetric
 
 	// Integration into local filesystem and remote services.
 	Log struct {

--- a/engine/queue.go
+++ b/engine/queue.go
@@ -1,0 +1,18 @@
+package engine
+
+import (
+	"github.com/jeffpierce/cassabon/config"
+)
+
+func QueueManager() {
+	for {
+		select {
+		case <-config.G.Quit:
+			config.G.Log.System.LogInfo("QueueManager received QUIT message")
+			config.G.WG.Done()
+			return
+		case metric := <-config.G.QueueManager:
+			config.G.Log.Carbon.LogDebug("QueueManager received metric: %v", metric)
+		}
+	}
+}

--- a/engine/rollup.go
+++ b/engine/rollup.go
@@ -1,0 +1,1 @@
+package engine

--- a/engine/workers.go
+++ b/engine/workers.go
@@ -1,0 +1,1 @@
+package engine

--- a/listener/carbon_plaintext.go
+++ b/listener/carbon_plaintext.go
@@ -14,13 +14,6 @@ import (
 	"github.com/jeffpierce/cassabon/logging"
 )
 
-// CarbonMetric is the canonical representation of Carbon data.
-type CarbonMetric struct {
-	Path      string  // Metric path
-	Value     float64 // Metric Value
-	Timestamp float64 // Epoch timestamp
-}
-
 // CarbonTCP listens for incoming Carbon TCP traffic and dispatches it.
 func CarbonTCP(addr string, port string) {
 
@@ -183,8 +176,7 @@ func metricHandler(line string) {
 		return
 	}
 
-	// Assemble into canonical struct and send to enqueueing worker.
-	parsedMetric := CarbonMetric{statPath, val, ts}
-	config.G.Log.Carbon.LogDebug("Woohoo! Pushing metric into channel: %v", parsedMetric)
+	// Assemble into canonical struct and send to queue manager.
+	config.G.QueueManager <- config.CarbonMetric{statPath, val, ts}
 	logging.Statsd.Client.Inc("cassabon.carbon.received.success", 1, 1.0)
 }


### PR DESCRIPTION
It was necessary to move the definition of CarbonMetric from "listener" to "config" in order to avoid an import cycle.