### PR TITLE
Standardize application abort processing

### DIFF
--- a/cassabon.go
+++ b/cassabon.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -16,6 +17,13 @@ import (
 
 func main() {
 
+	// Recover cleanly from panics with a message to stderr.
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Fprintf(os.Stderr, "ABORT: %v\n", err)
+		}
+	}()
+
 	// The name of the YAML configuration file.
 	var confFile string
 
@@ -24,9 +32,8 @@ func main() {
 	flag.Parse()
 
 	// Read the configuration file from disk.
-	// This will PANIC ON ERRORS, because the logger is not yet available.
 	if err := config.ReadConfigurationFile(confFile); err != nil {
-		panic(err)
+		panic(fmt.Errorf("Unable to load configuration: %v", err))
 	}
 	// Populate the global config with values used only once.
 	config.LoadStartupValues()

--- a/cassabon.go
+++ b/cassabon.go
@@ -38,7 +38,7 @@ func main() {
 
 	// Read the configuration file from disk.
 	if err := config.ReadConfigurationFile(confFile); err != nil {
-		panic(fmt.Errorf("Unable to load configuration: %v", err))
+		config.G.Log.System.LogFatal("Unable to load configuration: %v", err)
 	}
 	// Populate the global config with values used only once.
 	config.LoadStartupValues()

--- a/cassabon.go
+++ b/cassabon.go
@@ -31,6 +31,11 @@ func main() {
 	flag.StringVar(&confFile, "conf", "config/cassabon.yaml", "Location of YAML configuration file.")
 	flag.Parse()
 
+	// Create the loggers.
+	config.G.Log.System = logging.NewLogger("system")
+	config.G.Log.Carbon = logging.NewLogger("carbon")
+	config.G.Log.API = logging.NewLogger("api")
+
 	// Read the configuration file from disk.
 	if err := config.ReadConfigurationFile(confFile); err != nil {
 		panic(fmt.Errorf("Unable to load configuration: %v", err))
@@ -42,13 +47,13 @@ func main() {
 	sev, errLogLevel := logging.TextToSeverity(config.G.Log.Loglevel)
 	if config.G.Log.Logdir != "" {
 		logDir, _ := filepath.Abs(config.G.Log.Logdir)
-		config.G.Log.System = logging.NewLogger("system", filepath.Join(logDir, "cassabon.system.log"), sev)
-		config.G.Log.Carbon = logging.NewLogger("carbon", filepath.Join(logDir, "cassabon.carbon.log"), sev)
-		config.G.Log.API = logging.NewLogger("api", filepath.Join(logDir, "cassabon.api.log"), logging.Unclassified)
+		config.G.Log.System.Open(filepath.Join(logDir, "cassabon.system.log"), sev)
+		config.G.Log.Carbon.Open(filepath.Join(logDir, "cassabon.carbon.log"), sev)
+		config.G.Log.API.Open(filepath.Join(logDir, "cassabon.api.log"), logging.Unclassified)
 	} else {
-		config.G.Log.System = logging.NewLogger("system", "", sev)
-		config.G.Log.Carbon = logging.NewLogger("carbon", "", sev)
-		config.G.Log.API = logging.NewLogger("api", "", logging.Unclassified)
+		config.G.Log.System.Open("", sev)
+		config.G.Log.Carbon.Open("", sev)
+		config.G.Log.API.Open("", logging.Unclassified)
 	}
 	defer config.G.Log.System.Close()
 	defer config.G.Log.Carbon.Close()

--- a/cassabon.go
+++ b/cassabon.go
@@ -21,6 +21,7 @@ func main() {
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Fprintf(os.Stderr, "ABORT: %v\n", err)
+			os.Exit(1) // Let OS know we aborted
 		}
 	}()
 

--- a/cassabon.go
+++ b/cassabon.go
@@ -25,7 +25,9 @@ func main() {
 
 	// Read the configuration file from disk.
 	// This will PANIC ON ERRORS, because the logger is not yet available.
-	config.ReadConfigurationFile(confFile, false)
+	if err := config.ReadConfigurationFile(confFile); err != nil {
+		panic(err)
+	}
 	// Populate the global config with values used only once.
 	config.LoadStartupValues()
 
@@ -106,7 +108,7 @@ func main() {
 		// Re-read the configuration to get any updated values.
 		if configIsStale {
 			config.G.Log.System.LogInfo("Reading configuration file %s", confFile)
-			if err := config.ReadConfigurationFile(confFile, true); err != nil {
+			if err := config.ReadConfigurationFile(confFile); err != nil {
 				config.G.Log.System.LogError("Unable to load configuration: %v", err)
 			} else {
 				config.LoadRefreshableValues()

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -84,29 +84,15 @@ type StatsdSettings struct {
 var rawCassabonConfig *CassabonConfig
 
 // ReadConfigurationFile reads the contents of the specified file from disk, and unmarshals it.
-// First time through we have no logger, so we can't log warnings or errors. Panic instead.
-func ReadConfigurationFile(configFile string, haveLogger bool) error {
+func ReadConfigurationFile(configFile string) error {
 
 	// Read the configuration file.
 	yamlConfig, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		if haveLogger {
-			return err
-		} else {
-			panic(err)
-		}
+	if err == nil {
+		// Unmarshal config file contents into raw config struct.
+		err = yaml.Unmarshal(yamlConfig, &rawCassabonConfig)
 	}
-
-	// Unmarshal config file contents into raw config struct.
-	err = yaml.Unmarshal(yamlConfig, &rawCassabonConfig)
-	if err != nil {
-		if haveLogger {
-			return err
-		} else {
-			panic(err)
-		}
-	}
-	return nil
+	return err
 }
 
 // LoadStartupValues populates the global config object with values that are used only once.

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -188,7 +187,6 @@ func LoadRefreshableValues() {
 	// Ensure addresses are valid, and that the local address:port is in the peer list.
 	if err := ValidatePeerList(G.Carbon.Listen, G.Carbon.Peers); err != nil {
 		G.Log.System.LogFatal(err.Error())
-		os.Exit(1)
 	}
 
 	// Copy in and sanitize the Carbon TCP listener timeout.

--- a/config/config_parser_test.go
+++ b/config/config_parser_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	// Load yaml into config struct
-	ReadConfigurationFile("config_test.yaml", false)
+	ReadConfigurationFile("config_test.yaml")
 
 	/*
 		// Ensure we have a struct

--- a/datastore/index.go
+++ b/datastore/index.go
@@ -2,7 +2,6 @@
 package datastore
 
 import (
-	"os"
 	"strconv"
 	"strings"
 
@@ -49,7 +48,6 @@ func (indexer *MetricsIndexer) run() {
 		// Without Redis client we can't do our job, so log, whine, and crash.
 		config.G.Log.System.LogFatal("Indexer unable to connect to Redis at %v: %v",
 			config.G.Redis.Index.Addr, err)
-		os.Exit(10)
 	}
 
 	defer indexer.rc.Close()

--- a/datastore/retrieve.go
+++ b/datastore/retrieve.go
@@ -3,7 +3,6 @@ package datastore
 
 import (
 	"encoding/json"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -58,7 +57,6 @@ func (gopher *StatPathGopher) run() {
 		// Without Redis client we can't do our job, so log, whine, and crash.
 		config.G.Log.System.LogFatal("Gopher unable to connect to Redis at %v: %v",
 			config.G.Redis.Index.Addr, err)
-		os.Exit(11)
 	}
 
 	defer gopher.rc.Close()

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -1,7 +1,6 @@
 package datastore
 
 import (
-	"os"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -101,7 +100,6 @@ func (sm *StoreManager) run() {
 		// Without Cassandra client we can't do our job, so log, whine, and crash.
 		config.G.Log.System.LogFatal("StoreManager unable to connect to Cassandra at %v, port %s: %v",
 			config.G.Cassandra.Hosts, config.G.Cassandra.Port, err)
-		os.Exit(10)
 	}
 
 	defer sm.dbClient.Close()

--- a/init/CentOS/sysconfig
+++ b/init/CentOS/sysconfig
@@ -10,7 +10,8 @@ PIDFILE=/var/run/cassabon.pid
 EXEC=/usr/local/bin/cassabon
 
 # The options to pass to daemonize.
-DOPTIONS=
+# -e - where to write stderr application output. Overwritten on each start.
+DOPTIONS="-e /var/log/cassabon/stderr"
 
 # The options to pass to the application.
 OPTIONS=-conf=/etc/cassabon.yaml

--- a/listener/carbon_plaintext.go
+++ b/listener/carbon_plaintext.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"bytes"
 	"net"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -73,7 +72,6 @@ func (cpl *CarbonPlaintextListener) carbonTCP(hostPort string) {
 	if err != nil {
 		// If we can't grab a port, we can't do our job.  Log, whine, and crash.
 		config.G.Log.System.LogFatal("Cannot listen for Carbon on TCP: %v", err)
-		os.Exit(3)
 	}
 	defer tcpListener.Close()
 	config.G.Log.System.LogInfo("Listening on %s TCP for Carbon plaintext protocol", tcpListener.Addr().String())
@@ -122,7 +120,6 @@ func (cpl *CarbonPlaintextListener) carbonUDP(hostPort string) {
 	if err != nil {
 		// If we can't grab a port, we can't do our job.  Log, whine, and crash.
 		config.G.Log.System.LogFatal("Cannot listen for Carbon on UDP: %v", err)
-		os.Exit(3)
 	}
 	defer udpConn.Close()
 	config.G.Log.System.LogInfo("Listening on %s UDP for Carbon plaintext protocol", udpConn.LocalAddr().String())

--- a/listener/carbon_plaintext_test.go
+++ b/listener/carbon_plaintext_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestCarbonSocket(t *testing.T) {
 
-	config.G.Log.System = logging.NewLogger("system", "", logging.Info)
+	config.G.Log.System = logging.NewLogger("system")
+	config.G.Log.System.Open("", logging.Info)
 	logging.Statsd.Open("", "", "cassabon")
 
 	fmt.Println("Testing TCP socket connection...")

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -184,6 +184,7 @@ func (l *FileLogger) LogFatal(format string, a ...interface{}) {
 		defer l.m.RUnlock()
 		l.emit(Fatal, format, a...)
 	}
+	panic(fmt.Errorf(format, a...))
 }
 
 // reopen closes and re-opens the log file to support log rotation.
@@ -208,14 +209,9 @@ func (l *FileLogger) openLogfile() *os.File {
 			// DO NOT call the public Log() method, you will cause a deadlock.
 			l.emit(Fatal, "Unable to reopen logfile '%v'. Error: '%v'", l.logFilename, err)
 			l.logFile.Close()
-		} else {
-			// The startup case.
-			// Warning: when started as a daemon, this may go to /dev/null.
-			fmt.Printf("[-] ["+severityText[Fatal]+"] Unable to open logfile '%v'. Error: '%v'\n", l.logFilename, err)
 		}
-		// Inability to log is a fatal error; die with a non-zero exit code.
-		// We do not run blind.
-		os.Exit(1)
+		// Inability to log is a fatal error. We do not run blind.
+		panic(fmt.Errorf("Unable to (re)open logfile '%v'. Error: '%v'", l.logFilename, err))
 	}
 
 	return fp

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -21,7 +21,7 @@ func TestLogger(t *testing.T) {
 	L.Close()
 
 	L.Open(LOGFILE, Debug)
-	L.LogFatal("Logging at level DEBUG")
+	L.emit(Fatal, "Logging at level DEBUG")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
 	L.LogWarn("Hello %s!", "warn")
@@ -29,7 +29,7 @@ func TestLogger(t *testing.T) {
 	L.Close()
 
 	L.Open(LOGFILE, Info)
-	L.LogFatal("Logging at level INFO")
+	L.emit(Fatal, "Logging at level INFO")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
 	L.LogWarn("Hello %s!", "warn")
@@ -37,7 +37,7 @@ func TestLogger(t *testing.T) {
 	L.Close()
 
 	L.Open(LOGFILE, Warn)
-	L.LogFatal("Logging at level WARN")
+	L.emit(Fatal, "Logging at level WARN")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
 	L.LogWarn("Hello %s!", "warn")
@@ -45,7 +45,7 @@ func TestLogger(t *testing.T) {
 	L.Close()
 
 	L.Open(LOGFILE, Error)
-	L.LogFatal("Logging at level ERROR")
+	L.emit(Fatal, "Logging at level ERROR")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
 	L.LogWarn("Hello %s!", "warn")
@@ -53,7 +53,7 @@ func TestLogger(t *testing.T) {
 	L.Close()
 
 	L.Open(LOGFILE, Fatal)
-	L.LogFatal("Logging at level FATAL")
+	L.emit(Fatal, "Logging at level FATAL")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
 	L.LogWarn("Hello %s!", "warn")

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -14,12 +14,13 @@ func TestLogger(t *testing.T) {
 	os.Remove(LOGFILE)
 
 	L := new(FileLogger)
+	L.init(FACILITY)
 
-	L.open(FACILITY, "", Debug)
+	L.Open("", Debug)
 	L.LogDebug("Hello %s!", "world")
 	L.Close()
 
-	L.open(FACILITY, LOGFILE, Debug)
+	L.Open(LOGFILE, Debug)
 	L.LogFatal("Logging at level DEBUG")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
@@ -27,7 +28,7 @@ func TestLogger(t *testing.T) {
 	L.LogError("Hello %s!", "error")
 	L.Close()
 
-	L.open(FACILITY, LOGFILE, Info)
+	L.Open(LOGFILE, Info)
 	L.LogFatal("Logging at level INFO")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
@@ -35,7 +36,7 @@ func TestLogger(t *testing.T) {
 	L.LogError("Hello %s!", "error")
 	L.Close()
 
-	L.open(FACILITY, LOGFILE, Warn)
+	L.Open(LOGFILE, Warn)
 	L.LogFatal("Logging at level WARN")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
@@ -43,7 +44,7 @@ func TestLogger(t *testing.T) {
 	L.LogError("Hello %s!", "error")
 	L.Close()
 
-	L.open(FACILITY, LOGFILE, Error)
+	L.Open(LOGFILE, Error)
 	L.LogFatal("Logging at level ERROR")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")
@@ -51,7 +52,7 @@ func TestLogger(t *testing.T) {
 	L.LogError("Hello %s!", "error")
 	L.Close()
 
-	L.open(FACILITY, LOGFILE, Fatal)
+	L.Open(LOGFILE, Fatal)
 	L.LogFatal("Logging at level FATAL")
 	L.LogDebug("Hello %s!", "debug")
 	L.LogInfo("Hello %s!", "info")


### PR DESCRIPTION
LogFatal now causes a Go panic, which the main() function catches and writes to stderr.