### PR TITLE
Make database creation automatic

### DIFF
--- a/cassabon.go
+++ b/cassabon.go
@@ -42,9 +42,9 @@ func main() {
 	sev, errLogLevel := logging.TextToSeverity(config.G.Log.Loglevel)
 	if config.G.Log.Logdir != "" {
 		logDir, _ := filepath.Abs(config.G.Log.Logdir)
-		config.G.Log.System.Open(filepath.Join(logDir, "cassabon.system.log"), sev)
-		config.G.Log.Carbon.Open(filepath.Join(logDir, "cassabon.carbon.log"), logging.Unclassified)
-		config.G.Log.API.Open(filepath.Join(logDir, "cassabon.api.log"), logging.Unclassified)
+		config.G.Log.System.Open(filepath.Join(logDir, "system.log"), sev)
+		config.G.Log.Carbon.Open(filepath.Join(logDir, "carbon.log"), logging.Unclassified)
+		config.G.Log.API.Open(filepath.Join(logDir, "api.log"), logging.Unclassified)
 	} else {
 		config.G.Log.System.Open("", sev)
 		config.G.Log.Carbon.Open("", logging.Unclassified)

--- a/cassabon.go
+++ b/cassabon.go
@@ -43,11 +43,11 @@ func main() {
 	if config.G.Log.Logdir != "" {
 		logDir, _ := filepath.Abs(config.G.Log.Logdir)
 		config.G.Log.System.Open(filepath.Join(logDir, "cassabon.system.log"), sev)
-		config.G.Log.Carbon.Open(filepath.Join(logDir, "cassabon.carbon.log"), sev)
+		config.G.Log.Carbon.Open(filepath.Join(logDir, "cassabon.carbon.log"), logging.Unclassified)
 		config.G.Log.API.Open(filepath.Join(logDir, "cassabon.api.log"), logging.Unclassified)
 	} else {
 		config.G.Log.System.Open("", sev)
-		config.G.Log.Carbon.Open("", sev)
+		config.G.Log.Carbon.Open("", logging.Unclassified)
 		config.G.Log.API.Open("", logging.Unclassified)
 	}
 	defer config.G.Log.System.Close()

--- a/config/cassabon.yaml.template
+++ b/config/cassabon.yaml.template
@@ -38,6 +38,9 @@ cassandra:
     hosts:
         - "127.0.0.1"
     port: 9042
+    keyspace: "cassabon_dev"
+    strategy: "SimpleStrategy"
+    createopts: "'replication_factor':1"
 redis:
     index:
         addr:

--- a/config/cassabon.yaml.template
+++ b/config/cassabon.yaml.template
@@ -42,20 +42,13 @@ cassandra:
     strategy: "SimpleStrategy"
     createopts: "'replication_factor':1"
 redis:
-    index:
-        addr:
-            - "127.0.0.1:6379"
-        db: 5
-        pwd: ""
-        sentinel: false
-        master: ""
-    queue:
-        addr:
-            - "127.0.0.1:6379"
-        db: 6
-        pwd: ""
-        sentinel: false
-        master: ""
+    addr:
+        - "127.0.0.1:6379"
+    db: 5
+    pwd: ""
+    pathkeyname: "cassabon_dev"
+    sentinel: false
+    master: ""
 #
 # Rollups could be re-processed when all rollup accumulators have been flushed,
 # but this is not implemented. Full restart is required when rollups change.

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -39,11 +39,8 @@ type CassabonConfig struct {
 		HealthCheckFile string // Location of healthcheck file.
 	}
 	Cassandra CassandraSettings
-	Redis     struct {
-		Index RedisSettings // Settings for Redis Index
-		Queue RedisSettings // Settings for Redis Queue
-	}
-	Rollups map[string]RollupSettings // Map of regex and rollups
+	Redis     RedisSettings
+	Rollups   map[string]RollupSettings // Map of regex and rollups
 }
 
 // Definition of each rollup
@@ -63,11 +60,12 @@ type CassandraSettings struct {
 
 // Redis struct for redis connection information
 type RedisSettings struct {
-	Sentinel bool     // True if sentinel, false if standalone.
-	Addr     []string // List of addresses in host:port format
-	DB       int64    // Redis DB number for the index.
-	Pwd      string   // Password for Redis.
-	Master   string   // Master config name for sentinel settings.
+	Addr        []string // List of addresses in host:port format
+	DB          int64    // Redis DB number for the index.
+	Pwd         string   // Password for Redis.
+	PathKeyname string   // Name of the key under which paths are indexed
+	Sentinel    bool     // True if sentinel, false if standalone.
+	Master      string   // Master config name for sentinel settings.
 }
 
 type StatsdSettings struct {
@@ -224,8 +222,10 @@ func LoadRefreshableValues() {
 	}
 
 	// Copy in the Redis database connection values.
-	G.Redis.Index = rawCassabonConfig.Redis.Index
-	G.Redis.Queue = rawCassabonConfig.Redis.Queue
+	G.Redis = rawCassabonConfig.Redis
+	if G.Redis.PathKeyname == "" {
+		G.Redis.PathKeyname = "cassabon"
+	}
 }
 
 // LoadRollups populates the global config object with the rollup definitions,

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -219,6 +219,9 @@ func LoadRefreshableValues() {
 
 	// Copy in the Cassandra database connection values.
 	G.Cassandra = rawCassabonConfig.Cassandra
+	if G.Cassandra.Keyspace == "" {
+		G.Cassandra.Keyspace = "cassabon"
+	}
 
 	// Copy in the Redis database connection values.
 	G.Redis.Index = rawCassabonConfig.Redis.Index

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -38,11 +38,8 @@ type CassabonConfig struct {
 		Listen          string // HTTP API listens on this address:port
 		HealthCheckFile string // Location of healthcheck file.
 	}
-	Cassandra struct {
-		Hosts []string // List of hostnames or IP addresses of Cassandra ring
-		Port  string   // Cassandra port
-	}
-	Redis struct {
+	Cassandra CassandraSettings
+	Redis     struct {
 		Index RedisSettings // Settings for Redis Index
 		Queue RedisSettings // Settings for Redis Queue
 	}
@@ -53,6 +50,15 @@ type CassabonConfig struct {
 type RollupSettings struct {
 	Retention   []string
 	Aggregation string
+}
+
+// Cassandra connection and schema information
+type CassandraSettings struct {
+	Hosts      []string // List of hostnames or IP addresses of Cassandra ring
+	Port       string   // Cassandra port
+	Keyspace   string   // Name of the Cassandra keyspace
+	Strategy   string   // Replication class of the keyspace
+	CreateOpts string   // CQL text for the strategy options
 }
 
 // Redis struct for redis connection information

--- a/config/globals.go
+++ b/config/globals.go
@@ -108,10 +108,7 @@ type Globals struct {
 		HealthCheckFile string // Health check file.
 	}
 
-	Cassandra struct {
-		Hosts []string // List of hostnames or IP addresses of Cassandra ring
-		Port  string   // Cassandra port
-	}
+	Cassandra CassandraSettings
 
 	Redis struct {
 		Index RedisSettings // Settings for Redis Index

--- a/config/globals.go
+++ b/config/globals.go
@@ -110,10 +110,7 @@ type Globals struct {
 
 	Cassandra CassandraSettings
 
-	Redis struct {
-		Index RedisSettings // Settings for Redis Index
-		Queue RedisSettings // Settings for Redis Queue
-	}
+	Redis RedisSettings
 
 	// Configuration of data rollups.
 	RollupPriority []string             // First matched expression wins

--- a/datastore/index.go
+++ b/datastore/index.go
@@ -29,27 +29,27 @@ func (indexer *MetricsIndexer) run() {
 
 	// Initialize Redis client pool.
 	var err error
-	if config.G.Redis.Index.Sentinel {
+	if config.G.Redis.Sentinel {
 		config.G.Log.System.LogDebug("Indexer initializing Redis client (Sentinel)")
 		indexer.rc, err = middleware.RedisFailoverClient(
-			config.G.Redis.Index.Addr,
-			config.G.Redis.Index.Pwd,
-			config.G.Redis.Index.Master,
-			config.G.Redis.Index.DB,
+			config.G.Redis.Addr,
+			config.G.Redis.Pwd,
+			config.G.Redis.Master,
+			config.G.Redis.DB,
 		)
 	} else {
 		config.G.Log.System.LogDebug("Indexer initializing Redis client")
 		indexer.rc, err = middleware.RedisClient(
-			config.G.Redis.Index.Addr,
-			config.G.Redis.Index.Pwd,
-			config.G.Redis.Index.DB,
+			config.G.Redis.Addr,
+			config.G.Redis.Pwd,
+			config.G.Redis.DB,
 		)
 	}
 
 	if err != nil {
 		// Without Redis client we can't do our job, so log, whine, and crash.
 		config.G.Log.System.LogFatal("Indexer unable to connect to Redis at %v: %v",
-			config.G.Redis.Index.Addr, err)
+			config.G.Redis.Addr, err)
 	}
 
 	defer indexer.rc.Close()
@@ -99,7 +99,7 @@ func (indexer *MetricsIndexer) processMetricPath(splitPath []string, pathLen int
 		z := redis.Z{0, metricPath}
 
 		// Put it in the pipeline.
-		pipe.ZAdd("cassabon", z)
+		pipe.ZAdd(config.G.Redis.PathKeyname, z)
 
 		// Pop the last node of the metric off, set isLeaf to false, and resume loop.
 		_, splitPath = splitPath[len(splitPath)-1], splitPath[:len(splitPath)-1]

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -281,24 +281,31 @@ func (sm *StoreManager) flush(terminating bool) {
 		// Inspect each rollup window defined for this expression.
 		for i, windowEnd := range rl.nextWriteTime {
 
-			// If the window has closed, process and clear the data.
-			if windowEnd.Before(baseTime) {
+			// If the window has closed, or if terminating, process and clear the data.
+			if windowEnd.Before(baseTime) || terminating {
+
+				var statTime time.Time
+				if terminating {
+					statTime = baseTime
+				} else {
+					statTime = windowEnd
+				}
 
 				// Iterate over all the paths that match the current expression.
 				for path, rollup := range rl.path {
 
 					// Has any data accumulated while the window was open?
 					if rollup.count[i] > 0 {
-						// TODO: Write the data to persistent storage.
-						config.G.Log.System.LogInfo("Write expr=%s win=%v ret=%v ts=%v path=%s value=%.4f",
+
+						config.G.Log.System.LogInfo("Write expr=%q win=%v ret=%v ts=%v path=%s value=%.4f",
 							expr,
 							sm.rollup[expr].Windows[i].Window,
 							sm.rollup[expr].Windows[i].Retention,
-							windowEnd.Format("15:04:05.000"), // Window end time
+							statTime.Format("15:04:05.000"), // Window end time
 							path,
 							rollup.value[i])
 
-						sm.write(path, windowEnd, rollup.value[i], sm.rollup[expr].Windows[i].Table)
+						sm.write(path, statTime, rollup.value[i], sm.rollup[expr].Windows[i].Table)
 					}
 
 					// Ensure the bucket is empty for the next open window.
@@ -309,36 +316,6 @@ func (sm *StoreManager) flush(terminating bool) {
 				// Set a new window closing time for the just-cleared window.
 				rl.nextWriteTime[i] = nextTimeBoundary(baseTime, sm.rollup[expr].Windows[i].Window)
 			}
-
-			// If terminating, write out all remaining data, stamped with current time.
-			if terminating {
-
-				// Iterate over all the paths that match the current expression.
-				for path, rollup := range rl.path {
-
-					// Has any data accumulated while the window was open?
-					if rollup.count[i] > 0 {
-						// TODO: Write the data to persistent storage.
-						config.G.Log.System.LogInfo("Write expr=%s win=%v ret=%v ts=%v path=%s value=%.4f",
-							expr,
-							sm.rollup[expr].Windows[i].Window,
-							sm.rollup[expr].Windows[i].Retention,
-							baseTime.Format("15:04:05.000"), // Current time, window end is in future
-							path,
-							rollup.value[i])
-
-						sm.write(path, baseTime, rollup.value[i], sm.rollup[expr].Windows[i].Table)
-					}
-
-					// Ensure the bucket is empty for the next open window.
-					rollup.count[i] = 0
-					rollup.value[i] = 0
-				}
-
-				// Set a new window closing time for the just-cleared window.
-				rl.nextWriteTime[i] = nextTimeBoundary(baseTime, sm.rollup[expr].Windows[i].Window)
-			}
-
 			// ASSERT: rl.nextWriteTime[i] time is in the future (later than baseTime).
 
 			// Adjust the timer delay downwards if this window closing time is

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -339,8 +339,8 @@ func (sm *StoreManager) flush(terminating bool) {
 // flush persists the accumulated metrics to the database.
 func (sm *StoreManager) write(expr string, w config.RollupWindow, path string, ts time.Time, value float64) {
 
-	config.G.Log.System.LogInfo("Write expr=%q cf=%s win=%v ret=%v ts=%v path=%s value=%.4f",
-		expr, w.Table, w.Window, w.Retention, ts.Format("15:04:05.000"), path, value)
+	config.G.Log.Carbon.LogInfo("match=%q tbl=%s ts=%v path=%s val=%.4f win=%v ret=%v ",
+		expr, w.Table, ts.Format("15:04:05.000"), path, value, w.Window, w.Retention)
 
 	query := fmt.Sprintf(`INSERT INTO cassabon.%s (path, timestamp, stat) VALUES (?, ?, ?)`, w.Table)
 	if err := sm.dbClient.Query(query, path, ts, value).Exec(); err != nil {

--- a/init/CentOS/logrotate
+++ b/init/CentOS/logrotate
@@ -1,4 +1,4 @@
-/var/log/cassabon/cassabon.api.log /var/log/cassabon/cassabon.carbon.log /var/log/cassabon/cassabon.system.log {
+/var/log/cassabon/api.log /var/log/cassabon/carbon.log /var/log/cassabon/system.log {
     weekly
     missingok
     notifempty

--- a/middleware/cassandra.go
+++ b/middleware/cassandra.go
@@ -14,12 +14,10 @@ func CassandraSession(chosts []string, cport string, ckeyspace string) (*gocql.S
 	port, _ := strconv.ParseInt(cport, 10, 64)
 
 	// Build a cluster configuration.
-	cass := gocql.NewCluster(chosts...)
-
-	cass.Port = int(port)
-	cass.DiscoverHosts = true
-	cass.Keyspace = ckeyspace
+	clusterCfg := gocql.NewCluster(chosts...)
+	clusterCfg.Port = int(port)
+	clusterCfg.DiscoverHosts = true
 
 	// Create session.
-	return cass.CreateSession()
+	return clusterCfg.CreateSession()
 }

--- a/middleware/cassandra.go
+++ b/middleware/cassandra.go
@@ -17,6 +17,7 @@ func CassandraSession(chosts []string, cport string, ckeyspace string) (*gocql.S
 	clusterCfg := gocql.NewCluster(chosts...)
 	clusterCfg.Port = int(port)
 	clusterCfg.DiscoverHosts = true
+	clusterCfg.Keyspace = ckeyspace
 
 	// Create session.
 	return clusterCfg.CreateSession()


### PR DESCRIPTION
This PR adds the following functionality:

- Cassandra keyspace and Redis key names are defined in the config YAML
- Cassandra keyspace creation options are defined in the config YAML
- If the Cassandra keyspace does not exist at startup, it is created
- The Redis configuration has been simplified by removing the "queue" config
- Some minor refactoring for clarity