### PR TITLE
Ensure that the waitgroup that is incremented is the one decremented

### DIFF
--- a/config/globals.go
+++ b/config/globals.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/jeffpierce/cassabon/logging"
@@ -81,9 +80,6 @@ type Globals struct {
 	OnReload1       chan struct{}
 	OnReload2       chan struct{}
 	OnExit          chan struct{}
-	OnReload1WG     sync.WaitGroup
-	OnReload2WG     sync.WaitGroup
-	OnExitWG        sync.WaitGroup
 
 	// Channels for communicating between modules.
 	Channels struct {


### PR DESCRIPTION
By passing a waitgroup to Start() and using that throughout, it no
longer is possible to execute "wg.Done()" on the wrong waitgroup.