### PR TITLE
Ensure that the batch insert queue is always serviced

### DIFF
--- a/datastore/metricmanager.go
+++ b/datastore/metricmanager.go
@@ -181,6 +181,7 @@ func (mm *MetricManager) writer() {
 
 	// The queue for the batches we receive on the insert channel.
 	var queue []queueEntry
+	const numberOfRetries = 5
 
 	for {
 		select {
@@ -189,9 +190,8 @@ func (mm *MetricManager) writer() {
 			mm.writerWG.Done()
 			return
 		case batch := <-mm.insert:
-			// First property is the number of retries.
-			queue = append(queue, queueEntry{5, batch})
-		case <-time.After(time.Millisecond * 10):
+			queue = append(queue, queueEntry{numberOfRetries, batch})
+		case <-time.After(time.Second):
 			for len(queue) > 0 {
 				qe := queue[0]
 				queue = queue[1:]
@@ -203,6 +203,16 @@ func (mm *MetricManager) writer() {
 						queue = append(queue, qe) // Stick it back in the queue
 					}
 					break // On errors, wait for the next timeout before retrying
+				}
+				// Drain the queue after each write, so it can't fill up.
+				checkForMore := true
+				for checkForMore {
+					select {
+					case batch := <-mm.insert:
+						queue = append(queue, queueEntry{numberOfRetries, batch})
+					default:
+						checkForMore = false
+					}
 				}
 			}
 		}

--- a/datastore/metricmanager.go
+++ b/datastore/metricmanager.go
@@ -204,7 +204,7 @@ func (mm *MetricManager) writer() {
 					}
 					break // On errors, wait for the next timeout before retrying
 				}
-				// Drain the queue after each write, so it can't fill up.
+				// Drain the channel after each write, so it can't fill up.
 				checkForMore := true
 				for checkForMore {
 					select {


### PR DESCRIPTION
After every batch write, drain the input channel. With this change, we
are always responsive on the channel, and can make the timeout interval
much longer. This is better for CPU usage, and also for delaying before
a retry.