### PR TITLE
Produce accurate stat arrays to HTTP clients

### DIFF
--- a/cassabon.go
+++ b/cassabon.go
@@ -21,7 +21,7 @@ func main() {
 	defer config.G.OnPanic()
 
 	// The name of the YAML configuration file.
-	var confFile string
+	var confFile, loglevel string
 
 	// The WaitGroups for managing orderly goroutine reloads and termination.
 	var onReload1WG sync.WaitGroup // Wait on this if you receive external inputs
@@ -29,7 +29,8 @@ func main() {
 	var onExitWG sync.WaitGroup    // Wait on this for final program termination
 
 	// Get options provided on the command line.
-	flag.StringVar(&confFile, "conf", "config/cassabon.yaml", "Location of YAML configuration file.")
+	flag.StringVar(&confFile, "conf", "config/cassabon.yaml", "Location of YAML configuration file")
+	flag.StringVar(&loglevel, "loglevel", "", "logging level, to override configuration until SIGHUP")
 	flag.Parse()
 
 	// Create the loggers.
@@ -45,6 +46,10 @@ func main() {
 	config.LoadStartupValues()
 
 	// Set up logging.
+	if len(loglevel) > 0 {
+		// This will revert to the configured value at the first SIGHUP.
+		config.G.Log.Loglevel = loglevel
+	}
 	sev, errLogLevel := logging.TextToSeverity(config.G.Log.Loglevel)
 	if config.G.Log.Logdir != "" {
 		logDir, _ := filepath.Abs(config.G.Log.Logdir)

--- a/config/config_parser.go
+++ b/config/config_parser.go
@@ -116,6 +116,18 @@ func LoadStartupValues() {
 	// Copy in the statsd configuration.
 	G.Statsd = rawCassabonConfig.Statsd
 
+	// Copy in the Cassandra database connection values.
+	G.Cassandra = rawCassabonConfig.Cassandra
+	if G.Cassandra.Keyspace == "" {
+		G.Cassandra.Keyspace = "cassabon"
+	}
+
+	// Copy in the Redis database connection values.
+	G.Redis = rawCassabonConfig.Redis
+	if G.Redis.PathKeyname == "" {
+		G.Redis.PathKeyname = "cassabon"
+	}
+
 	// Copy in and sanitize the channel lengths.
 	G.Channels.MetricStoreChanLen = rawCassabonConfig.Channels.MetricStoreChanLen
 	if G.Channels.MetricStoreChanLen < 10 {
@@ -245,18 +257,6 @@ func LoadRefreshableValues() {
 	G.API.Timeouts.DeleteIndex = time.Duration(time.Duration(rawCassabonConfig.API.Timeouts.DeleteIndex) * time.Second)
 	G.API.Timeouts.GetMetric = time.Duration(time.Duration(rawCassabonConfig.API.Timeouts.GetMetric) * time.Second)
 	G.API.Timeouts.DeleteMetric = time.Duration(time.Duration(rawCassabonConfig.API.Timeouts.DeleteMetric) * time.Second)
-
-	// Copy in the Cassandra database connection values.
-	G.Cassandra = rawCassabonConfig.Cassandra
-	if G.Cassandra.Keyspace == "" {
-		G.Cassandra.Keyspace = "cassabon"
-	}
-
-	// Copy in the Redis database connection values.
-	G.Redis = rawCassabonConfig.Redis
-	if G.Redis.PathKeyname == "" {
-		G.Redis.PathKeyname = "cassabon"
-	}
 }
 
 // LoadRollups populates the global config object with the rollup definitions,

--- a/datastore/metricmanager.go
+++ b/datastore/metricmanager.go
@@ -561,6 +561,18 @@ func (mm *MetricManager) queryGET(q config.MetricQuery) {
 
 			// Append the current stat.
 			if ts.Equal(nextTS) {
+				if mergeCount > 0 {
+					config.G.Log.System.LogDebug("---: %14.8f %v ( %v )", stat,
+						ts.Format("15:04:05.000"), nextTS.UTC().Format("15:04:05.000"))
+					mergeValue = mm.applyMethod(mm.rollup[expr].Method, mergeValue, stat, mergeCount)
+					mergeCount++
+					if mm.rollup[expr].Method == config.AVERAGE {
+						mergeValue = mergeValue / float64(mergeCount)
+					}
+					stat = mergeValue
+					mergeValue = 0
+					mergeCount = 0
+				}
 				config.G.Log.System.LogDebug("row: %14.8f %v ( %v )", stat,
 					ts.Format("15:04:05.000"), nextTS.UTC().Format("15:04:05.000"))
 				if math.IsNaN(stat) {

--- a/datastore/metricmanager.go
+++ b/datastore/metricmanager.go
@@ -416,7 +416,7 @@ func (mm *MetricManager) flush(terminating bool) {
 							config.G.Log.Carbon.LogInfo(
 								"match=%q tbl=%s ts=%v path=%s val=%.4f win=%v ret=%v ",
 								expr, mm.rollup[expr].Windows[i].Table,
-								statTime.Format("15:04:05.000"), path, value,
+								statTime.UTC().Format("15:04:05.000"), path, value,
 								mm.rollup[expr].Windows[i].Window, mm.rollup[expr].Windows[i].Retention)
 						}
 

--- a/devtools/get_metrics.sh
+++ b/devtools/get_metrics.sh
@@ -16,6 +16,9 @@ case $1 in
 esac
 
 echo "Start of query range: `date -j -r $FROM`"
-echo "curl -X GET" \""127.0.0.1:8080/metrics?path=foo.bar.baz.count&path=foo.bar.baz.min&path=foo.bar.baz.max&path=foo.bar.baz.sum&path=foo.bar.baz.average&from=$FROM&to=$TO"\"
-curl -X GET "127.0.0.1:8080/metrics?path=foo.bar.baz.count&path=foo.bar.baz.min&path=foo.bar.baz.max&path=foo.bar.baz.sum&path=foo.bar.baz.average&from=$FROM&to=$TO"
-echo ""
+
+for p in foo.bar.baz.count foo.bar.baz.min foo.bar.baz.max foo.bar.baz.sum foo.bar.baz.average; do
+    echo "curl -X GET" \""127.0.0.1:8080/metrics?path=${p}&from=$FROM&to=$TO"\"
+    curl -X GET "127.0.0.1:8080/metrics?path=${p}&from=$FROM&to=$TO"
+    echo ""
+done


### PR DESCRIPTION
This ensures that every stat for the requested interval is represented in the returned array once, and only once. All partial entries are rolled up into a single data point, calculated to be accurate at the end of the rollup interval.

The only remaining inaccuracy is in the combining of partial averages, but this is intractable, and unlikely to be statistically significant in practice.