### PR TITLE
Centralize all API stats timing in the request logger

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -64,7 +64,6 @@ func (api *CassabonAPI) notFoundHandler(w http.ResponseWriter, r *http.Request) 
 
 // healthHandler responds with either ALIVE or DEAD, for use by the load balancer.
 func (api *CassabonAPI) healthHandler(w http.ResponseWriter, r *http.Request) {
-	hht := time.Now()
 
 	// We are alive, unless the healthcheck file says we are dead.
 	var alive bool = true
@@ -80,12 +79,10 @@ func (api *CassabonAPI) healthHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		fmt.Fprint(w, "DEAD")
 	}
-	logging.Statsd.Client.TimingDuration("api.health", time.Since(hht), 1.0)
 }
 
 // rootHandler provides information about the application, served from "/".
 func (api *CassabonAPI) rootHandler(w http.ResponseWriter, r *http.Request) {
-	rt := time.Now()
 
 	resp := struct {
 		Message string `json:"message"`
@@ -97,12 +94,10 @@ func (api *CassabonAPI) rootHandler(w http.ResponseWriter, r *http.Request) {
 	resp.Version = config.Version
 	jsonText, _ := json.Marshal(resp)
 	w.Write(jsonText)
-	logging.Statsd.Client.TimingDuration("api.root", time.Since(rt), 1.0)
 }
 
 // getPathHandler processes requests like "GET /paths?query=foo".
 func (api *CassabonAPI) getPathHandler(w http.ResponseWriter, r *http.Request) {
-	gpt := time.Now()
 
 	// Create the channel on which the response will be received.
 	ch := make(chan config.APIQueryResponse)
@@ -124,12 +119,10 @@ func (api *CassabonAPI) getPathHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Send the response to the client.
 	api.sendResponse(w, ch, config.G.API.Timeouts.GetIndex)
-	logging.Statsd.Client.TimingDuration("api.path.get", time.Since(gpt), 1.0)
 }
 
 // deletePathHandler removes paths from the index store.
 func (api *CassabonAPI) deletePathHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	dpt := time.Now()
 
 	// Create the channel on which the response will be received.
 	ch := make(chan config.APIQueryResponse)
@@ -150,12 +143,10 @@ func (api *CassabonAPI) deletePathHandler(c web.C, w http.ResponseWriter, r *htt
 
 	// Send the response to the client.
 	api.sendResponse(w, ch, config.G.API.Timeouts.DeleteIndex)
-	logging.Statsd.Client.TimingDuration("api.path.delete", time.Since(dpt), 1.0)
 }
 
 // getMetricHandler processes requests like "GET /metrics?query=foo".
 func (api *CassabonAPI) getMetricHandler(w http.ResponseWriter, r *http.Request) {
-	gmt := time.Now()
 
 	// Create the channel on which the response will be received.
 	ch := make(chan config.APIQueryResponse)
@@ -179,12 +170,10 @@ func (api *CassabonAPI) getMetricHandler(w http.ResponseWriter, r *http.Request)
 
 	// Send the response to the client.
 	api.sendResponse(w, ch, config.G.API.Timeouts.GetMetric)
-	logging.Statsd.Client.TimingDuration("api.metrics.get", time.Since(gmt), 1.0)
 }
 
 // deleteMetricHandler removes data from the metrics store.
 func (api *CassabonAPI) deleteMetricHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	dmt := time.Now()
 
 	// Create the channel on which the response will be received.
 	ch := make(chan config.APIQueryResponse)
@@ -205,7 +194,6 @@ func (api *CassabonAPI) deleteMetricHandler(c web.C, w http.ResponseWriter, r *h
 
 	// Send the response to the client.
 	api.sendResponse(w, ch, config.G.API.Timeouts.DeleteMetric)
-	logging.Statsd.Client.TimingDuration("api.metrics.delete", time.Since(dmt), 1.0)
 }
 
 func (api *CassabonAPI) sendResponse(w http.ResponseWriter, ch chan config.APIQueryResponse, timeout time.Duration) {

--- a/api/requestlogger.go
+++ b/api/requestlogger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zenazn/goji/web/mutil"
 
 	"github.com/jeffpierce/cassabon/config"
+	"github.com/jeffpierce/cassabon/logging"
 )
 
 // requestLogger handler emits access and trace log entries.
@@ -29,11 +30,22 @@ func requestLogger(c *web.C, h http.Handler) http.Handler {
 		remoteHost := strings.Split(r.RemoteAddr, ":")[0]
 		status := lw.Status()
 		size := lw.BytesWritten()
-		duration := t2.Sub(t1).Nanoseconds() / 1000
+		duration := t2.Sub(t1)
+
+		// Assemble the data for the stats entry.
+		stats := strings.Split(r.RequestURI, "?")
+		stats = strings.Split(stats[0], "/")
+		if stats[1] == "" {
+			stats[1] = "root"
+		}
+		stats = []string{"api", stats[1], strings.ToLower(r.Method)}
+
+		// Write the stats entry.
+		logging.Statsd.Client.TimingDuration(strings.Join(stats, "."), duration, 1.0)
 
 		// Write the log entry to the access log.
 		config.G.Log.API.LogInfo("%s %s %s %s status=%d size=%d dur=%d",
-			remoteHost, r.Method, r.Proto, r.RequestURI, status, size, duration)
+			remoteHost, r.Method, r.Proto, r.RequestURI, status, size, duration.Nanoseconds()/1000)
 	}
 
 	return http.HandlerFunc(fn)

--- a/datastore/indexmanager.go
+++ b/datastore/indexmanager.go
@@ -138,13 +138,9 @@ func (im *IndexManager) processMetricPath(splitPath []string, pathLen int, isLea
 func (im *IndexManager) query(q config.IndexQuery) {
 	switch strings.ToLower(q.Method) {
 	case "delete":
-		qdt := time.Now()
 		// TODO
-		logging.Statsd.Client.TimingDuration("indexmgr.query.delete", time.Since(qdt), 1.0)
 	default:
-		qgt := time.Now()
 		im.queryGET(q)
-		logging.Statsd.Client.TimingDuration("indexmgr.query.get", time.Since(qgt), 1.0)
 	}
 }
 

--- a/datastore/metricmanager.go
+++ b/datastore/metricmanager.go
@@ -476,13 +476,9 @@ func (mm *MetricManager) flush(terminating bool) {
 func (mm *MetricManager) query(q config.MetricQuery) {
 	switch strings.ToLower(q.Method) {
 	case "delete":
-		mqdt := time.Now()
 		// TODO
-		logging.Statsd.Client.TimingDuration("metricmgr.query.delete", time.Since(mqdt), 1.0)
 	default:
-		mqgt := time.Now()
 		mm.queryGET(q)
-		logging.Statsd.Client.TimingDuration("metricmgr.query.get", time.Since(mqgt), 1.0)
 	}
 }
 


### PR DESCRIPTION
This uses generated stat paths, of the form

    "api" + first URI path element + request method

Examples:

cassabon.api.root.get:0.210021|ms
cassabon.api.healthcheck.get:0.114042|ms
cassabon.api.metrics.get:2.813781|ms
cassabon.api.paths.get:0.321252|ms

The healthcheck path is changed from "api.health" before this commit.