### PR TITLE
Fix flakey listener test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   override:
     - rm -rf ~/.go_workspace/src/github.com/jeffpierce/cassabon
+    - mkdir -p ~/.go_workspace/src/github.com/jeffpierce
     - ln -sf ~/cassabon ~/.go_workspace/src/github.com/jeffpierce/cassabon
     - make clean build
 

--- a/listener/carbon_plaintext_test.go
+++ b/listener/carbon_plaintext_test.go
@@ -29,22 +29,35 @@ func TestCarbonSocket(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		fmt.Println("Sending good metric to TCP...")
-		tcpconn, _ := net.Dial("tcp", "127.0.0.1:2003")
-		GoodMetric(tcpconn)
-		tcpconn.Close()
+		if tcpconn, err := net.Dial("tcp", "127.0.0.1:2003"); err == nil {
+			GoodMetric(tcpconn)
+			tcpconn.Close()
+		} else {
+			fmt.Printf("Unable to open TCP connection: %s\n", err.Error())
+		}
 	}
 
 	fmt.Println("Sending bad metric to TCP...")
-	tcpconnbad, _ := net.Dial("tcp", "127.0.0.1:2003")
-	BadMetric(tcpconnbad)
+	if tcpconnbad, err := net.Dial("tcp", "127.0.0.1:2003"); err == nil {
+		BadMetric(tcpconnbad)
+		tcpconnbad.Close()
+	} else {
+		fmt.Printf("Unable to open TCP connection: %s\n", err.Error())
+	}
 
 	fmt.Println("Sending good metric to UDP...")
-	udpconn, _ := net.Dial("udp", "127.0.0.1:2003")
-	GoodMetric(udpconn)
+	if udpconn, err := net.Dial("udp", "127.0.0.1:2003"); err == nil {
+		GoodMetric(udpconn)
+	} else {
+		fmt.Printf("Unable to open UDP connection: %s\n", err.Error())
+	}
 
 	fmt.Println("Sending bad metric to UDP...")
-	udpconnbad, _ := net.Dial("udp", "127.0.0.1:2003")
-	BadMetric(udpconnbad)
+	if udpconnbad, err := net.Dial("udp", "127.0.0.1:2003"); err == nil {
+		BadMetric(udpconnbad)
+	} else {
+		fmt.Printf("Unable to open UDP connection: %s\n", err.Error())
+	}
 
 	time.Sleep(100 * time.Millisecond)
 }


### PR DESCRIPTION
When the carbon listener test cannot open a TCP/UDP connection to test the listener, that's a failure of the test platform, not the app.

This PR prevents crashing on a null pointer when the test fails to open a TCP connection.
